### PR TITLE
Report issues as VS Code "problems"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+- [3](https://github.com/johnallen3d/vscode-cue-fmt/pull/3): Report issues as VS Code "problems" - [@johnallen3d](https://github.com/johnallen3d)
+
 ## [0.0.3] - 2021-12-19
 
 - [3df1a01](https://github.com/johnallen3d/vscode-cue-fmt/commit/3df1a01): Show error message - [@johnallen3d](https://github.com/johnallen3d)


### PR DESCRIPTION
When `cue fmt .` results in error(s), those error(s) will now be reported as "problems" (underline and on problems tab).

Resolves #2

<img width="606" alt="vscode-cue-fmt_problems" src="https://user-images.githubusercontent.com/184915/146796169-50ce0631-2031-4905-8d94-882a8741deeb.png">

