### PR TITLE
Improve release note generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - maintenance

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,7 @@
 # Release
 
+
+
 Steps to release new version.
 
 ## Prepare and Merge Release Pull Request
@@ -11,10 +13,11 @@ Create a pull request to represent a new release.
 1. Update `./CHANGELOG.md`
 1. Commit changes following commit title convention: `Bump vscode-cue-fmt from 0.0.1 to 0.0.2`
 
-## Trigge a Release to VS Code Marketplace
+## Trigger a Release to VS Code Marketplace
 
 After the release PR has been merged, push version tag to trigger the release action on GitHub.
 
 1. Tag release commit: `git tag -m "v0.0.1" -a "v0.0.1"`
 1. Push changes: `git push --tags`
+1. Create a GitHub Release: `gh release create v0.1.1 --generate-notes --title vscode-cue-fmt 0.1.1`
 1. ...wait, it takes a couple of minutes for change to be available in Marketplace

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,5 @@
 # Release
 
-
-
 Steps to release new version.
 
 ## Prepare and Merge Release Pull Request
@@ -15,7 +13,7 @@ Create a pull request to represent a new release.
 
 ## Trigger a Release to VS Code Marketplace
 
-After the release PR has been merged, push version tag to trigger the release action on GitHub.
+After merging the release PR, push version tag to trigger the release action on GitHub.
 
 1. Tag release commit: `git tag -m "v0.0.1" -a "v0.0.1"`
 1. Push changes: `git push --tags`


### PR DESCRIPTION
- take advantage of the latest `gh release` to auto-generate release notes
- exclude PR's marked as `maintenance` in release notes
